### PR TITLE
authz filter: allow "/dicom-web/studies?StudyInstanceUID=abc"

### DIFF
--- a/orthanc-gen3/authz_filter.py
+++ b/orthanc-gen3/authz_filter.py
@@ -64,7 +64,7 @@ def check_authorization(uri, **request):
         logger.debug("Accessing /system")
         return True
 
-    if uri.startswith("/dicom-web/studies/"):
+    if uri.startswith("/dicom-web/studies/") or uri == "/dicom-web/studies":
         try:
             study_id = uri.split("/")[3]
         except IndexError:

--- a/orthanc-gen3/authz_filter.py
+++ b/orthanc-gen3/authz_filter.py
@@ -64,7 +64,10 @@ def check_authorization(uri, **request):
         logger.debug("Accessing /system")
         return True
 
-    if uri.startswith("/dicom-web/studies/") or uri == "/dicom-web/studies":
+    if uri == "/dicom-web/studies":
+        resource = "/services/dicom-viewer/studies"
+        method = "read"
+    elif uri.startswith("/dicom-web/studies/"):
         try:
             study_id = uri.split("/")[3]
         except IndexError:

--- a/orthanc-gen3/authz_filter.py
+++ b/orthanc-gen3/authz_filter.py
@@ -64,17 +64,21 @@ def check_authorization(uri, **request):
         logger.debug("Accessing /system")
         return True
 
-    if uri == "/dicom-web/studies":
-        resource = "/services/dicom-viewer/studies"
-        method = "read"
-    elif uri.startswith("/dicom-web/studies/"):
-        try:
-            study_id = uri.split("/")[3]
-        except IndexError:
-            logger.error(f"Unable to parse study ID from URI: {uri}. Denying access")
-            return False
-        logger.debug(f"User accessing study: {study_id} (URI: {uri})")
-        resource = f"/services/dicom-viewer/studies/{study_id}"
+    if uri == "/dicom-web/studies" or uri.startswith("/dicom-web/studies/"):
+        study_id = None
+        if uri == "/dicom-web/studies":  # Ohif viewer V3
+            study_id = request.get("get", {}).get("StudyInstanceUID")
+        else:  # Ohif viewer V2 and V3
+            try:
+                study_id = uri.split("/")[3]
+            except IndexError:
+                logger.error(f"Unable to parse study ID from URI: {uri}. Denying access")
+                return False
+        if study_id:
+            logger.debug(f"User accessing study: {study_id} (URI: {uri})")
+            resource = f"/services/dicom-viewer/studies/{study_id}"
+        else:
+            resource = "/services/dicom-viewer/studies"
         method = "read"
     else:
         logger.debug(f"By default, admin access is required to access {uri}")


### PR DESCRIPTION
This update allows URI "/dicom-web/studies" to fix this issue when loading studies:
```
By default, admin access is required to access /dicom-web/studies
```

Ohif viewer V2 only made requests like `/dicom-web/studies/abc`. V3 still makes those (main image), but also makes requests like `/dicom-web/studies?StudyInstanceUID=abc` (left panel images).

Example of URL that returns 403:
`/dicom-server/dicom-web/studies?limit=101&offset=0&fuzzymatching=false&includefield=00081030%2C00080060&StudyInstanceUID=<redacted>`.
